### PR TITLE
Handle exception of WebClient to recover the headers

### DIFF
--- a/src/Services/DiagramService.cs
+++ b/src/Services/DiagramService.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace PlantUmlLanguageService.Services
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class DiagramService
     {
@@ -43,8 +43,17 @@ namespace PlantUmlLanguageService.Services
             if (uri != Constants.NoImageBase64)
             {
                 var client = new WebClient();
-                string result = await client.DownloadStringTaskAsync(uri);
-                WebHeaderCollection response = client.ResponseHeaders;
+                WebHeaderCollection response;
+                try
+                {
+                    string result = await client.DownloadStringTaskAsync(uri);
+                    response = client.ResponseHeaders;
+                }
+                catch (WebException e)
+                {
+                    // in this case, the headers are in the exception.Response
+                    response = e.Response.Headers;
+                }
                 try
                 {
                     Global.Validator = new Validator(response.Get("X-PlantUML-Diagram-Description"), response.Get("X-PlantUML-Diagram-Error"), response.Get("X-PlantUML-Diagram-Error-Line"));


### PR DESCRIPTION
Handle exception of WebClient to recover the response headers from the exception instead of the client...

[Before this, in case of syntax errors, WebClient throws and the {} in the preview keep showing up, but not error report].

Now the headers are also passed into the Validator and the correct badge displayed.